### PR TITLE
fix(download): extract zips in-process — Deno.run is gone in Deno 2

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -71,6 +71,7 @@
     "@std/io": "jsr:@std/io@^0.225.3",
     "@std/path": "jsr:@std/path@^1.1.6",
     "@std/streams": "jsr:@std/streams@^1.1.1",
+    "@zip-js/zip-js": "jsr:@zip-js/zip-js@2.8.34",
     "webdav": "npm:webdav",
     "https://deno.land/std/node/util.ts": "node:util",
     "https://deno.land/std/node/events.ts": "node:events",

--- a/deno.lock
+++ b/deno.lock
@@ -41,6 +41,7 @@
     "jsr:@std/semver@^1.0.8": "1.0.8",
     "jsr:@std/streams@^1.1.1": "1.1.1",
     "jsr:@std/text@^1.0.19": "1.0.19",
+    "jsr:@zip-js/zip-js@2.8.34": "2.8.34",
     "npm:@anatine/zod-openapi@2.2.6": "2.2.6_openapi3-ts@4.6.0_zod@3.23.8",
     "npm:@openapitools/openapi-generator-cli@^2.9.0": "2.40.1",
     "npm:awesome-phonenumber@7.1.0": "7.1.0",
@@ -230,6 +231,9 @@
     },
     "@std/text@1.0.19": {
       "integrity": "003a0e032d360e8c3a4e0410fb792c77a66bd6553fee9d60c6ec1bce30d29223"
+    },
+    "@zip-js/zip-js@2.8.34": {
+      "integrity": "65f9aff4ace08c738c3e3887975a206e4976ecfc7e1b62a876bc7c848ae5cb0b"
     }
   },
   "npm": {
@@ -1440,6 +1444,7 @@
       "jsr:@std/io@~0.225.3",
       "jsr:@std/path@^1.1.6",
       "jsr:@std/streams@^1.1.1",
+      "jsr:@zip-js/zip-js@2.8.34",
       "npm:webdav@*"
     ],
     "packageJson": {

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -1,6 +1,5 @@
 import {AppModule} from './app.module.ts';
 import {WebSocketModule} from './mod/io/protocols/websocket/websocket.module.ts';
-import { bundle, transpile } from "https://deno.land/x/emit/mod.ts";
 import * as path from "@std/path";
 import {DanetApplication, Logger} from "@danet/core";
 import {SpecBuilder, SwaggerModule} from "@danet/swagger";

--- a/src/mod/io/protocols/http/download/client.service.ts
+++ b/src/mod/io/protocols/http/download/client.service.ts
@@ -1,4 +1,4 @@
-import { decompress } from "https://deno.land/x/zip/mod.ts";
+import { BlobReader, Uint8ArrayWriter, ZipReader } from "@zip-js/zip-js";
 import { Untar } from "@std/archive";
 import { copy, readerFromStreamReader } from "@std/io";
 import  * as path from "@std/path";
@@ -116,7 +116,7 @@ export class CoreDownloadService {
     }
 
     if (fullPath.endsWith(".zip")) {
-      await decompress(fullPath, dir, { includeFileName: false });
+      await this.unzip(fullPath, dir);
     } else if (fullPath.endsWith(".tar")) {
       const reader = await Deno.open(fullPath, { read: true });
       const untar = new Untar(reader);
@@ -205,5 +205,47 @@ export class CoreDownloadService {
 
     //Deno.writeFileSync(fullPath, unit8arr, mode);
     return Promise.resolve({ file, dir, fullPath, size });
+  }
+
+  /**
+   * Extracts a .zip archive into a directory.
+   *
+   * Reads the archive in-process rather than handing it to `unzip` or
+   * PowerShell. A compiled binary is meant to run on a host with nothing
+   * installed, so depending on an external extractor would make extraction
+   * work on the developer's machine and fail on the user's.
+   *
+   * @param {string} archive Path to the .zip file
+   * @param {string} dir Directory to extract into
+   * @returns {Promise<void>}
+   */
+  async unzip(archive: string, dir: string): Promise<void> {
+    const reader = new ZipReader(
+      new BlobReader(new Blob([await Deno.readFile(archive)])),
+    );
+    try {
+      const root = await Deno.realPath(dir);
+      for (const entry of await reader.getEntries()) {
+        // An archive names its own paths, and nothing stops one naming
+        // `../../etc/thing`. Resolve each entry and refuse any that lands
+        // outside the directory we were asked to extract into.
+        const target = path.resolve(root, entry.filename);
+        if (target !== root && !target.startsWith(root + path.SEPARATOR)) {
+          this.log.error(`refusing entry outside ${dir}: ${entry.filename}`);
+          continue;
+        }
+        if (entry.directory) {
+          await ensureDir(target);
+          continue;
+        }
+        await ensureDir(path.dirname(target));
+        // getData is optional on the type because an entry read from a
+        // stream may not carry one; entries from a Blob always do.
+        const data = await entry.getData!(new Uint8ArrayWriter());
+        await Deno.writeFile(target, data);
+      }
+    } finally {
+      await reader.close();
+    }
   }
 }


### PR DESCRIPTION
## The bug

Every `.zip` download threw at runtime on Deno 2.

`deno.land/x/zip@v1.2.5`'s `decompress` is implemented with `Deno.run`, and closes the process with `Deno.close(rid)`. **Both were removed in Deno 2.**

```ts
const unzipCommandProcess = Deno.run({
  cmd: Deno.build.os === "windows"
    ? ["PowerShell", "Expand-Archive", ...]
    : ["unzip", zipSourcePath, "-d", destinationPath],
});
const processStatus = (await unzipCommandProcess.status()).success
Deno.close(unzipCommandProcess.rid)
```

It survived the Deno 1.x → 2 upgrade because `deno check` does not type-check remote modules. Nothing flagged it: the server type-checked clean, compiled clean, and failed on first use.

## Why not just pin a newer version

Shelling out is the wrong shape for this codebase. `deno compile` exists so the binary runs on a host with nothing installed on it — and that module required `unzip` on Unix and PowerShell on Windows. Extraction that works on the developer's machine and fails on the user's is worse than extraction that doesn't compile.

Extraction now runs in-process via `jsr:@zip-js/zip-js@2.8.34`.

## Path traversal

Entries are resolved against the target directory and refused if they land outside it. An archive names its own paths and nothing stops one naming `../../etc/thing` — the extractor this replaces handed that straight to `unzip`.

## Also

Drops a dead `import { bundle, transpile }` in `bootstrap.ts`. Neither identifier was used anywhere in the file, and the import pulled `deno.land/x/emit` — **unpinned**, resolving to whatever `latest` was at build time — into the compiled graph.

## Verification

Round-trip against a real archive containing a plain file, a nested file, and a traversal entry:

```
  [guard] refusing entry outside /var/folders/.../out: ../escaped.txt
hello.txt      : hello world
nested/deep.txt: nested content
escaped file written outside target: false
PASS
```

Graph and contract unchanged otherwise:

```
$ deno info mod.ts | grep -c 'deno.land/x'
0                     # was 10

$ deno check mod.ts
Check mod.ts

$ deno run -A mod.ts openapi   # openapi.json byte-identical, 40 paths
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Virgil <virgil@lethean.io>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved ZIP archive downloads with safer, in-process extraction.
  - Added protection against archive contents being written outside the intended destination.
  - Ensured extracted files and directories are handled reliably during downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->